### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/eestevez123/eddieEstevezPortfolio/security/code-scanning/1](https://github.com/eestevez123/eddieEstevezPortfolio/security/code-scanning/1)

In general, the fix is to explicitly declare minimal `GITHUB_TOKEN` permissions either at the workflow root or at the job level. For a simple Node.js CI workflow that just checks out code, installs dependencies, builds, and runs tests, only read access to repository contents is needed, so we can set `contents: read`. This prevents the `GITHUB_TOKEN` from having unnecessary write capabilities.

The best way to fix this specific workflow without altering behavior is to add a `permissions:` block at the top level (root of the workflow) so that it applies to all jobs. Place it after the `on:` trigger block and before `jobs:`. Concretely, in `.github/workflows/node.js.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 11 and 12 in the provided snippet. No additional imports, methods, or definitions are needed, because this is purely a configuration change in the GitHub Actions workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
